### PR TITLE
added current pins from napari-svg repo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
@@ -20,10 +20,10 @@ requirements:
     - pip
     - setuptools_scm
   run:
-    - imageio
-    - numpy
-    - napari-plugin-engine
-    - vispy
+    - imageio >=2.5.0
+    - numpy >=1.10.0
+    - napari-plugin-engine >=0.1.4
+    - vispy >=0.6.4
     - python >=3.6
 
 test:


### PR DESCRIPTION
This is related to https://github.com/conda-forge/napari-feedstock/issues/7
The changes would ideally go into the 0.1.3 version (as I haven't tracked back the pins for the 0.1.2) (so into https://github.com/conda-forge/napari-svg-feedstock/pull/1)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
